### PR TITLE
Laravel 11 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.2",
         "ext-json": "*",
-        "illuminate/contracts": "^10.14",
+        "illuminate/contracts": "^10.0|^11.0",
         "launchdarkly/server-sdk": "^6.0",
         "spatie/laravel-package-tools": "^1.15"
     },


### PR DESCRIPTION
Modified the `illuminate/contracts` dependency in `composer.json` to accept version 11.0 alongside 10.0. This change ensures compatibility with projects using either version.